### PR TITLE
Preserve capitalization in table headers

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -777,15 +777,18 @@
     if (label == null) {
       return '';
     }
-    const text = String(label);
+    const text = String(label).trim();
     if (!text) {
       return '';
     }
+    const upper = text.toUpperCase();
     const lower = text.toLowerCase();
-    if (!lower) {
-      return '';
+    const hasLetters = upper !== lower;
+    const isAllCaps = hasLetters && text === upper;
+    if (isAllCaps) {
+      return text;
     }
-    return lower.charAt(0).toUpperCase() + lower.slice(1);
+    return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
   function getStoredValue(key) {
@@ -3657,7 +3660,11 @@
     window.addEventListener('DOMContentLoaded', initApp);
   }
 
-  const exportsObject = { fmtDate: fmtDate, DEFAULT_LOCALE: DEFAULT_LOCALE };
+  const exportsObject = {
+    fmtDate: fmtDate,
+    DEFAULT_LOCALE: DEFAULT_LOCALE,
+    formatHeaderLabel: formatHeaderLabel
+  };
 
   if (typeof module !== 'undefined' && module.exports) {
     module.exports = exportsObject;

--- a/seguimiento_cargas_pwa/formatHeaderLabel.test.js
+++ b/seguimiento_cargas_pwa/formatHeaderLabel.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { formatHeaderLabel } = require('./app.js');
+
+assert.strictEqual(formatHeaderLabel('TR-MX'), 'TR-MX');
+assert.strictEqual(formatHeaderLabel('TR-USA'), 'TR-USA');
+assert.strictEqual(formatHeaderLabel('cliente'), 'Cliente');
+assert.strictEqual(formatHeaderLabel(' cita carga '), 'Cita carga');
+
+console.log('formatHeaderLabel tests passed.');


### PR DESCRIPTION
## Summary
- keep fully uppercase headers such as TR-MX and TR-USA from being lowercased
- expose formatHeaderLabel so helper tests can assert table header formatting
- cover formatHeaderLabel with a unit test to ensure original capitalization is preserved

## Testing
- node seguimiento_cargas_pwa/formatHeaderLabel.test.js
- node seguimiento_cargas_pwa/fmtDate.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d6ffbc2104832b9b74bfd4990af4b8