### PR TITLE
Reset filters when switching views

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -2653,6 +2653,7 @@
         return;
       }
       state.currentViewId = nextId;
+      resetFilters();
       renderViewMenu();
       renderTable();
       renderDateFilter();


### PR DESCRIPTION
## Summary
- reset stored filters whenever the user switches to a different table view so new views start with default data

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d7099ff5f4832bbae6f06495ce3347