### PR TITLE
Add Excel bulk upload trigger to UI

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -1051,6 +1051,8 @@
       viewMenu: doc.querySelector('[data-view-menu]'),
       status: doc.querySelector('[data-status]'),
       refreshButton: doc.querySelector('[data-action="refresh"]'),
+      bulkUploadButton: doc.querySelector('[data-action="bulk-upload"]'),
+      bulkUploadInput: doc.querySelector('[data-bulk-upload-input]'),
       newRecordButton: doc.querySelector('[data-action="new-record"]'),
       logoutButton: doc.querySelector('[data-action="logout"]'),
       changeTokenButton: doc.querySelector('[data-action="change-token"]'),
@@ -2739,6 +2741,9 @@
       if (refs.refreshButton) {
         refs.refreshButton.disabled = Boolean(isLoading);
       }
+      if (refs.bulkUploadButton) {
+        refs.bulkUploadButton.disabled = Boolean(isLoading);
+      }
       if (isLoading) {
         appRoot.classList.add('is-loading');
       } else {
@@ -3603,6 +3608,12 @@
       refs.refreshButton.addEventListener('click', function () {
         loadData();
       });
+    }
+    if (refs.bulkUploadButton) {
+      refs.bulkUploadButton.addEventListener('click', handleBulkUploadClick);
+    }
+    if (refs.bulkUploadInput) {
+      refs.bulkUploadInput.addEventListener('change', handleBulkUploadInputChange);
     }
     if (refs.newRecordButton) {
       refs.newRecordButton.addEventListener('click', function () {

--- a/seguimiento_cargas_pwa/index.html
+++ b/seguimiento_cargas_pwa/index.html
@@ -35,8 +35,17 @@
         </div>
         <button type="button" class="button button--secondary is-hidden" data-action="change-token">Cambiar token</button>
         <button type="button" class="button button--secondary" data-action="refresh">Actualizar</button>
+        <button type="button" class="button button--secondary" data-action="bulk-upload">Carga masiva</button>
         <button type="button" class="button button--primary" data-action="new-record">Nuevo registro</button>
         <button type="button" class="button button--secondary" data-action="logout">Cerrar sesión</button>
+        <input
+          type="file"
+          accept=".xlsx,.xlsm"
+          data-bulk-upload-input
+          class="visually-hidden"
+          tabindex="-1"
+          aria-hidden="true"
+        />
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- add a dedicated control to trigger Excel-based bulk uploads from the main toolbar
- wire the new control into the existing upload workflow and loading state handling

## Testing
- node tripValidation.test.js
- node bulkAddDuplicates.test.js
- node fmtDate.test.js
- node formatHeaderLabel.test.js
- node backend.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9f8bbb040832bb0b87f4a13b49443