### PR TITLE
Fix ISO date-only parsing for date filter

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -108,6 +108,17 @@
       };
     }
 
+    const isoDateOnlyMatch = value.match(/^([0-9]{4})-([0-9]{2})-([0-9]{2})$/);
+    if (isoDateOnlyMatch) {
+      return {
+        year: parseYear(isoDateOnlyMatch[1]),
+        month: parseInt(isoDateOnlyMatch[2], 10),
+        day: parseInt(isoDateOnlyMatch[3], 10),
+        hour: 0,
+        minute: 0
+      };
+    }
+
     const dmyMatch = value.match(/^([0-9]{1,2})[\/\-.]([0-9]{1,2})[\/\-.]([0-9]{2,4})(?:[ T]([0-9]{1,2}):([0-9]{2})(?::([0-9]{2}))?(?:\s*([AP])M)?)?$/i);
     if (dmyMatch) {
       let hour = dmyMatch[4] != null ? parseInt(dmyMatch[4], 10) : 0;

--- a/seguimiento_cargas_pwa/fmtDate.test.js
+++ b/seguimiento_cargas_pwa/fmtDate.test.js
@@ -8,6 +8,11 @@ assert.strictEqual(fmtDate(isoSample, DEFAULT_LOCALE), '09/06/2024 15:30');
 assert.strictEqual(fmtDate(isoSample, 'de-DE'), '09.06.2024 15:30');
 assert.strictEqual(fmtDate(isoSample), '09/06/2024 15:30');
 
+const isoDateOnlySample = '2025-09-01';
+assert.strictEqual(fmtDate(isoDateOnlySample, 'en-US'), '09/01/2025 00:00');
+assert.strictEqual(fmtDate(isoDateOnlySample, DEFAULT_LOCALE), '01/09/2025 00:00');
+assert.strictEqual(fmtDate(isoDateOnlySample, 'de-DE'), '01.09.2025 00:00');
+
 const customSample = '09/06/2024 15:30:00';
 
 assert.strictEqual(fmtDate(customSample, 'en-US'), '06/09/2024 15:30');


### PR DESCRIPTION
## Summary
- ensure YYYY-MM-DD strings are parsed without applying unintended timezone offsets
- keep the time components normalized when parsing ISO dates without an explicit time
- extend fmtDate test coverage to guard against regressions when handling date-only values

## Testing
- node fmtDate.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db18e9f6e0832bb0de6b94b0ad2e8c