### PR TITLE
Expand sheet layout to full viewport width

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -208,7 +208,7 @@ body {
 }
 
 .sheet-app {
-  width: min(1500px, 98vw);
+  width: min(100%, 100vw);
   margin: 0 auto;
   padding: clamp(var(--size-24), 3vh, var(--size-40))
     clamp(var(--size-16), 2.5vw, var(--size-32))


### PR DESCRIPTION
## Summary
- allow the main sheet layout to span the entire viewport width instead of capping at 1500px

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf03dc1d0832bb36556921081e062