### PR TITLE
Fix edit modal layout with dedicated scroll area

### DIFF
--- a/seguimiento_cargas_pwa/index.html
+++ b/seguimiento_cargas_pwa/index.html
@@ -144,7 +144,9 @@
 
   <section class="edit-modal hidden" data-edit-modal aria-modal="true" role="dialog" aria-labelledby="editTitle">
     <form class="edit-modal__form" data-edit-form novalidate>
-      <h2 id="editTitle" data-edit-title>Editar registro</h2>
+      <div class="edit-modal__header">
+        <h2 id="editTitle" data-edit-title>Editar registro</h2>
+      </div>
       <div class="edit-modal__content">
         <div class="edit-modal__grid">
         <div class="form-field">

--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -1138,9 +1138,20 @@ body {
 .edit-modal__form {
   display: flex;
   flex-direction: column;
-  gap: var(--size-16);
   height: 100%;
   width: 100%;
+  gap: var(--size-16);
+  overflow: hidden;
+}
+
+.edit-modal__header {
+  background: var(--modal-surface);
+  padding-bottom: var(--size-8);
+  border-bottom: var(--size-1) solid var(--sheet-border);
+}
+
+.edit-modal__header h2 {
+  margin: 0;
 }
 
 .login-modal__form h2,
@@ -1219,6 +1230,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--size-16);
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   padding-right: var(--size-4);
 }
@@ -1232,6 +1245,7 @@ body {
 }
 
 .edit-modal__actions {
+  flex-shrink: 0;
   padding-top: var(--size-16);
   border-top: var(--size-1) solid var(--sheet-border);
   background: var(--modal-surface);


### PR DESCRIPTION
## Summary
- wrap the edit modal heading in a fixed header container
- make the form content the only scrollable region while keeping the footer actions fixed

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbf5ac8ea4832b868829d3a6208901