### PR TITLE
Ensure edit modal can scroll within viewport

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -1133,6 +1133,14 @@ body {
 
 .edit-modal {
   width: min(var(--size-860), calc(100% - var(--size-48)));
+  height: min(calc(100vh - var(--size-80)), var(--size-980));
+}
+
+@supports (height: 100dvh) {
+  .edit-modal {
+    height: min(calc(100dvh - var(--size-80)), var(--size-980));
+    max-height: calc(100dvh - var(--size-80));
+  }
 }
 
 .edit-modal__form {
@@ -1239,6 +1247,8 @@ body {
   min-height: 0;
   overflow-y: auto;
   padding-right: var(--size-4);
+  padding-bottom: var(--size-16);
+  scrollbar-gutter: stable;
 }
 
 .login-modal__actions,


### PR DESCRIPTION
## Summary
- give the edit modal an explicit viewport-bound height so its content can scroll consistently
- add padding and a stable gutter to the scroll container to keep the final fields accessible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbfb716030832badff71880bb59572