### PR TITLE
Fix filter dropdown popover stacking

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -498,6 +498,8 @@ body {
   flex-wrap: wrap;
   justify-content: flex-start;
   backdrop-filter: var(--frosted-filter);
+  position: relative;
+  z-index: 5;
 }
 
 .filter-card {


### PR DESCRIPTION
## Summary
- ensure the filters toolbar creates a stacking context with a higher z-index so its popovers appear above the table headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbfe845e7c832b8b3202aff6007d8d