### PR TITLE
Adjust table font weight for consistency

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -936,12 +936,12 @@ body * {
 .sheet-table tbody td {
   transition: background var(--transition), box-shadow var(--transition);
   white-space: nowrap;
-  font-weight: 400;
+  font-weight: 300;
 }
 
 .sheet-table tbody td .table-link-button,
 .sheet-table tbody td .status-badge {
-  font-weight: 400;
+  font-weight: 300;
 }
 
 .sheet-table thead th {


### PR DESCRIPTION
## Summary
- lighten the typography used in table body cells so the data matches the rest of the interface styling
- ensure table link buttons and badges inherit the lighter weight for a consistent appearance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc121ab240832b99a09ef3e76d2d34