### PR TITLE
Remove bold text styling options

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -2422,6 +2422,24 @@
       wasStatusPopoverOpen = state.isStatusPopoverOpen;
     }
 
+    function getCellDisplayValue(cell) {
+      if (cell instanceof Date) {
+        return cell;
+      }
+      if (cell && typeof cell === 'object' && !Array.isArray(cell)) {
+        if (Object.prototype.hasOwnProperty.call(cell, 'value')) {
+          return getCellDisplayValue(cell.value);
+        }
+        if (Object.prototype.hasOwnProperty.call(cell, 'text')) {
+          return getCellDisplayValue(cell.text);
+        }
+        if (Object.prototype.hasOwnProperty.call(cell, 'displayValue')) {
+          return getCellDisplayValue(cell.displayValue);
+        }
+      }
+      return cell;
+    }
+
     function openStatusPopover() {
       if (state.isStatusPopoverOpen || state.availableStatuses.length === 0) {
         return;
@@ -3108,7 +3126,9 @@
           const td = doc.createElement('td');
           const headerLabel = headers[c];
           const columnKey = c < columnKeys.length ? columnKeys[c] : null;
-          let value = row && row[c] != null ? row[c] : '';
+          const rawCell = row && row[c] != null ? row[c] : '';
+          const cellValue = getCellDisplayValue(rawCell);
+          let value = cellValue != null ? cellValue : '';
           const isTripColumn = columnKey === 'trip';
           const isTrackingColumn = columnKey === 'tracking';
           const isStatusColumn = columnKey === 'estatus';

--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -212,6 +212,24 @@ body * {
   font-weight: 400;
 }
 
+body b,
+body strong,
+body .bold,
+body .fw-bold,
+body [data-text-type='bold'],
+body [style*='font-weight: bold'],
+body [style*='font-weight:bold'],
+body [style*='font-weight: 600'],
+body [style*='font-weight:600'],
+body [style*='font-weight: 700'],
+body [style*='font-weight:700'],
+body [style*='font-weight: 800'],
+body [style*='font-weight:800'],
+body [style*='font-weight: 900'],
+body [style*='font-weight:900'] {
+  font-weight: 400 !important;
+}
+
 .sheet-app {
   width: min(100%, 100vw);
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- override potential bold font selectors and inline styles so text always renders with regular weight
- normalize rendered table cell values to ignore formatting metadata such as bold requests

## Testing
- node formatHeaderLabel.test.js
- node fmtDate.test.js
- node bulkAddValidation.test.js
- node bulkAddDuplicates.test.js
- node backend.test.js
- node tripValidation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc1823d118832ba8258c640a4ad2f3