### PR TITLE
Add loading indicator overlay to sheet grid

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -1752,6 +1752,7 @@
     const refs = {
       tableHead: doc.querySelector('[data-table-head]'),
       tableBody: doc.querySelector('[data-table-body]'),
+      loadingIndicator: doc.querySelector('[data-loading-indicator]'),
       viewMenu: doc.querySelector('[data-view-menu]'),
       status: doc.querySelector('[data-status]'),
       refreshButton: doc.querySelector('[data-action="refresh"]'),
@@ -2670,6 +2671,9 @@
       }
       if (refs.bulkUploadButton) {
         refs.bulkUploadButton.disabled = Boolean(isLoading);
+      }
+      if (refs.loadingIndicator) {
+        refs.loadingIndicator.hidden = !isLoading;
       }
       if (isLoading) {
         appRoot.classList.add('is-loading');

--- a/seguimiento_cargas_pwa/index.html
+++ b/seguimiento_cargas_pwa/index.html
@@ -124,6 +124,7 @@
         </div>
       </div>
       <div class="sheet-grid__viewport" role="region" aria-live="polite" aria-label="Tabla de seguimiento">
+        <div class="loading-overlay" data-loading-indicator hidden></div>
         <table class="sheet-table">
           <thead data-table-head></thead>
           <tbody data-table-body></tbody>

--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -931,6 +931,48 @@ body [style*='font-weight:900'] {
   max-height: calc(100vh - var(--size-220));
   flex: 1 1 auto;
   min-height: 0;
+  position: relative;
+}
+
+[data-loading-indicator] {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 3;
+}
+
+.is-loading [data-loading-indicator] {
+  display: flex;
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(var(--size-6));
+}
+
+:root[data-theme='dark'] .is-loading [data-loading-indicator] {
+  background: rgba(12, 14, 24, 0.55);
+}
+
+.is-loading [data-loading-indicator]::after {
+  content: '';
+  width: var(--size-40);
+  height: var(--size-40);
+  border-radius: 50%;
+  border: var(--size-4) solid rgba(10, 132, 255, 0.25);
+  border-top-color: var(--accent);
+  animation: loading-spin 1s linear infinite;
+}
+
+.sheet-app.is-loading .sheet-table {
+  opacity: 0.4;
+  transition: opacity var(--transition);
+}
+
+@keyframes loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .sheet-table {
@@ -940,6 +982,7 @@ body [style*='font-weight:900'] {
   border-spacing: 0;
   font-size: 0.7rem;
   table-layout: auto;
+  transition: opacity var(--transition);
 }
 
 .sheet-table thead th,


### PR DESCRIPTION
## Summary
- add a loading overlay container inside the sheet grid viewport
- style the loading indicator overlay and fade the table while loading
- toggle the overlay visibility from the existing loading handler

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc6c557194832b8eb8dc402fd2e0ec