### PR TITLE
Evitar texto en negritas dentro de la tabla

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -1001,6 +1001,10 @@ body [style*='font-weight:900'] {
   font-weight: 400 !important;
 }
 
+.sheet-table tbody td * {
+  font-weight: 400 !important;
+}
+
 .sheet-table tbody td .table-link-button,
 .sheet-table tbody td .status-badge {
   font-weight: 300;


### PR DESCRIPTION
## Summary
- fuerza el peso tipográfico normal en todos los contenidos dentro de las celdas de la tabla para eliminar negritas accidentales

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dc700a4d68832b8638f922f5c079de