### PR TITLE
Reduce table font weight

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -1062,7 +1062,7 @@ h6 {
 }
 
 .sheet-table.sheet-table tbody td * {
-  font-weight: 400 !important;
+  font-weight: 300 !important;
 }
 
 .sheet-table tbody td .table-link-button,
@@ -1078,6 +1078,7 @@ h6 {
   text-transform: none !important;
   letter-spacing: normal !important;
   font-size: var(--font-size-sm);
+  font-weight: 300;
   border-bottom: var(--size-1) solid var(--table-header-border);
   box-shadow: inset 0 -var(--size-1) 0 var(--table-header-border);
   z-index: 2;
@@ -1087,7 +1088,7 @@ h6 {
 .sheet-table.sheet-table thead th,
 .sheet-table.sheet-table tbody th,
 .sheet-table.sheet-table tbody td {
-  font-weight: 400 !important;
+  font-weight: 300 !important;
 }
 
 .sheet-table tbody tr:nth-child(even) td {


### PR DESCRIPTION
## Summary
- lighten the typography of table headers and body cells to remove the bold appearance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd59f90a18832b98bec1f39a7e4e13