### PR TITLE
Reduce font weight in table cells

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -1062,12 +1062,12 @@ h6 {
 }
 
 .sheet-table.sheet-table tbody td * {
-  font-weight: 300 !important;
+  font-weight: 200 !important;
 }
 
 .sheet-table tbody td .table-link-button,
 .sheet-table tbody td .status-badge {
-  font-weight: 300;
+  font-weight: 200;
 }
 
 .sheet-table thead th {
@@ -1085,10 +1085,9 @@ h6 {
   backdrop-filter: blur(var(--size-4));
 }
 
-.sheet-table.sheet-table thead th,
 .sheet-table.sheet-table tbody th,
 .sheet-table.sheet-table tbody td {
-  font-weight: 300 !important;
+  font-weight: 200 !important;
 }
 
 .sheet-table tbody tr:nth-child(even) td {


### PR DESCRIPTION
## Summary
- reduce the default font weight applied to table body cells to soften the appearance of the records
- ensure nested elements inside cells, including buttons and badges, inherit the lighter typography while keeping header styling unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5bac1bc4832b872e5b13a15a76ec