### PR TITLE
Remove automatic zoom styling from dashboard views

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -2,7 +2,7 @@
 
 :root {
   color-scheme: light;
-  --app-scale: 0.75;
+  --app-scale: 1;
   --size-1: calc(1px * var(--app-scale));
   --size-2: calc(2px * var(--app-scale));
   --size-3: calc(3px * var(--app-scale));


### PR DESCRIPTION
## Summary
- remove the global app scale variable that applied zooming to tables across all views

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dd694191cc832ba0385ef76603acce