### PR TITLE
Ocultar encabezado central de Seguimiento de cargas

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -267,6 +267,7 @@ h6 {
 .sheet-app__title-group {
   grid-area: title;
   text-align: center;
+  display: none;
 }
 
 .sheet-app__title-group h1 {


### PR DESCRIPTION
## Summary
- ocultar el grupo de título principal en la barra superior para que no se muestre el texto "Seguimiento de cargas"

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ddb96aa184832b8f9c1c72486ae8f8