### PR TITLE
Update button styling to align with iOS pill aesthetics

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -376,17 +376,15 @@ h6 {
 }
 
 .button {
-  border: var(--size-1) solid var(--button-secondary-border);
-  background: var(--button-background);
+  border: var(--size-1) solid transparent;
+  background: transparent;
   color: var(--sheet-text);
   font-size: var(--font-size-sm);
   font-weight: normal;
   border-radius: var(--size-999);
   padding: var(--size-10) var(--size-20);
   cursor: pointer;
-  transition: transform var(--transition), background var(--transition), color var(--transition),
-    border-color var(--transition), box-shadow var(--transition);
-  box-shadow: var(--shadow-sm);
+  transition: background 180ms ease, color 180ms ease;
 }
 
 .button:focus {
@@ -395,16 +393,13 @@ h6 {
 }
 
 .button:hover {
-  background: var(--button-background-hover);
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px -16px rgba(17, 17, 20, 0.4);
+  background: transparent;
 }
 
 .button:disabled {
-  background: var(--sheet-surface-muted);
+  background: transparent;
   color: var(--sheet-text-soft);
-  border-color: var(--button-secondary-border);
-  box-shadow: none;
+  border-color: transparent;
   opacity: 0.6;
   cursor: not-allowed;
 }
@@ -413,13 +408,15 @@ h6 {
   background: var(--accent);
   color: var(--button-primary-text);
   border-color: var(--accent);
-  box-shadow: 0 18px 36px -18px var(--accent-shadow);
+  font-weight: 600;
+  min-height: 44px;
+  box-shadow: none;
 }
 
 .button--primary:hover {
-  background: var(--accent-hover);
+  background: var(--accent);
   color: var(--button-primary-text);
-  box-shadow: 0 22px 40px -20px var(--accent-shadow);
+  filter: brightness(1.05);
 }
 
 .button--primary:disabled {
@@ -429,23 +426,24 @@ h6 {
 }
 
 .button--secondary {
-  background: transparent;
+  background: rgba(118, 118, 128, 0.12);
   color: var(--sheet-text);
-  border-color: var(--button-secondary-border);
+  border-color: rgba(60, 60, 67, 0.18);
+  min-height: 44px;
   box-shadow: none;
 }
 
 .button--secondary:hover {
-  background: transparent;
-  border-color: var(--accent-border-weak);
+  background: rgba(118, 118, 128, 0.18);
+  border-color: rgba(60, 60, 67, 0.24);
   color: var(--sheet-text);
   box-shadow: none;
 }
 
 .button--secondary:disabled {
-  background: transparent;
+  background: rgba(118, 118, 128, 0.12);
   color: var(--sheet-text-soft);
-  border-color: var(--button-secondary-border);
+  border-color: rgba(60, 60, 67, 0.18);
 }
 
 .sheet-app__footer-item--status {


### PR DESCRIPTION
## Summary
- restyle the base button to remove shadows, enforce rounded pills, and share consistent background/color transitions
- update the primary button to use a solid accent fill with bolder typography and hover brightness adjustment
- refresh the secondary button with translucent backgrounds and borders that match the new design language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc04e51e8832babdf522983119068