### PR TITLE
Reduce app scale by 25%

### DIFF
--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -2,7 +2,7 @@
 
 :root {
   color-scheme: light;
-  --app-scale: 1;
+  --app-scale: 0.75;
   --size-1: calc(1px * var(--app-scale));
   --size-2: calc(2px * var(--app-scale));
   --size-3: calc(3px * var(--app-scale));


### PR DESCRIPTION
## Summary
- decrease the global --app-scale CSS variable to 0.75 so the interface renders 25% smaller

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ddc3bb9f34832ba081651a84b47dac