### PR TITLE
Remove 'at destination' from today's deliveries exclusions

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -473,7 +473,7 @@
   );
 
   const TODAY_DELIVERY_EXCLUDED_STATUS_SET = new Set(
-    ['at destination', 'delivered', 'cancelled'].map(function (status) {
+    ['delivered', 'cancelled'].map(function (status) {
       return status.toLowerCase();
     })
   );


### PR DESCRIPTION
## Summary
- update the today deliveries filter exclusions to allow the "at destination" status

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de88278f88832bb852f6a04f1b10e4