### PR TITLE
Resaltar columnas de citas con tono azul suave

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -3067,6 +3067,15 @@
         };
       });
 
+      const appointmentColumnIndices = ['citaCarga', 'llegadaCarga', 'citaEntrega', 'llegadaEntrega']
+        .map(function (key) {
+          return columnMap[key];
+        })
+        .filter(function (index) {
+          return typeof index === 'number' && index >= 0;
+        });
+      const appointmentColumnIndexSet = new Set(appointmentColumnIndices);
+
       const activeView = getActiveView();
       const filterContext = {
         columnMap: columnMap,
@@ -3281,6 +3290,9 @@
           const isTripColumn = columnKey === 'trip';
           const isTrackingColumn = columnKey === 'tracking';
           const isStatusColumn = columnKey === 'estatus';
+          if (appointmentColumnIndexSet.has(c)) {
+            td.classList.add('is-appointment-column');
+          }
           if (isDateHeader(headerLabel) && value !== '') {
             const formatted = fmtDate(value, state.locale);
             value = formatted || value;

--- a/seguimiento_cargas_pwa/styles.css
+++ b/seguimiento_cargas_pwa/styles.css
@@ -55,6 +55,8 @@
   --accent-border-weak: rgba(10, 132, 255, 0.24);
   --accent-border-strong: rgba(10, 132, 255, 0.5);
   --accent-shadow: rgba(10, 132, 255, 0.35);
+  --appointment-column-bg: rgba(10, 132, 255, 0.08);
+  --appointment-column-bg-hover: rgba(10, 132, 255, 0.18);
   --danger: #ff3b30;
   --success: #34c759;
   --status-default-bg: rgba(95, 99, 104, 0.12);
@@ -129,6 +131,8 @@
   --accent-border-weak: rgba(68, 156, 255, 0.45);
   --accent-border-strong: rgba(68, 156, 255, 0.75);
   --accent-shadow: rgba(21, 74, 138, 0.5);
+  --appointment-column-bg: rgba(43, 143, 255, 0.18);
+  --appointment-column-bg-hover: rgba(43, 143, 255, 0.32);
   --danger: #ff625a;
   --success: #2fdf84;
   --status-default-bg: rgba(76, 110, 153, 0.28);
@@ -1094,8 +1098,17 @@ h6 {
   backdrop-filter: blur(var(--size-4));
 }
 
+.sheet-table tbody td.is-appointment-column {
+  background: var(--appointment-column-bg);
+  transition: background-color var(--transition), background var(--transition);
+}
+
 .sheet-table tbody tr:hover td {
   background: var(--accent-surface);
+}
+
+.sheet-table tbody tr:hover td.is-appointment-column {
+  background: var(--appointment-column-bg-hover);
 }
 
 .sheet-table tbody tr:hover td:first-child {


### PR DESCRIPTION
## Summary
- añade detección de las columnas de citas y les aplica una clase dedicada al renderizar la tabla
- define colores tenues en ambos temas y estilos para resaltar las celdas de citas y su estado en hover

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea282dd24832baa2728b47403a1db