### PR TITLE
Limit confirmed appointments exclusions

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -510,7 +510,7 @@
   );
 
   const CONFIRMED_APPOINTMENTS_EXCLUDED_STATUS_SET = new Set(
-    ['delivered', 'live', 'drop', 'cancelled'].map(function (status) {
+    ['delivered', 'cancelled'].map(function (status) {
       return status.toLowerCase();
     })
   );


### PR DESCRIPTION
## Summary
- adjust confirmed appointments filter to only exclude delivered and cancelled statuses

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0578153b8832bbdb5de2087c8e905