### PR TITLE
Allow optional Ejecutivo in bulk uploads

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -1145,13 +1145,14 @@
   }
 
   const BULK_ALLOWED_EXTENSIONS = new Set(['xlsx', 'xlsm']);
-  const BULK_REQUIRED_HEADERS = ['Trip', 'Ejecutivo'];
+  const BULK_REQUIRED_HEADERS = ['Trip'];
   const BULK_TEXT_HEADERS = [
+    'Ejecutivo',
     'Caja',
-    'Estatus',
+    'Referencia',
     'Cliente',
     'Destino',
-    'Referencia',
+    'Estatus',
     'Segmento',
     'TR-MX',
     'TR-USA',
@@ -1160,7 +1161,24 @@
     'Tracking'
   ];
   const BULK_DATE_HEADERS = ['Cita carga', 'Llegada carga', 'Cita entrega', 'Llegada entrega'];
-  const BULK_OPTIONAL_HEADERS = BULK_TEXT_HEADERS.concat(BULK_DATE_HEADERS);
+  const BULK_OPTIONAL_HEADERS = [
+    'Ejecutivo',
+    'Caja',
+    'Referencia',
+    'Cliente',
+    'Destino',
+    'Estatus',
+    'Segmento',
+    'TR-MX',
+    'TR-USA',
+    'Cita carga',
+    'Llegada carga',
+    'Cita entrega',
+    'Llegada entrega',
+    'Comentarios',
+    'Docs',
+    'Tracking'
+  ];
   const BULK_CANONICAL_HEADERS = BULK_REQUIRED_HEADERS.concat(BULK_OPTIONAL_HEADERS);
   const BULK_HEADER_NORMALIZATION_MAP = (function () {
     const map = {};
@@ -1785,13 +1803,6 @@
         rowIssues.push('Trip menor a 225000');
       }
       output.Trip = tripValue;
-
-      const rawEjecutivo = normalizedValues.Ejecutivo;
-      const ejecutivoValue = rawEjecutivo == null ? '' : String(rawEjecutivo).trim();
-      if (!ejecutivoValue) {
-        rowIssues.push('Ejecutivo vacío');
-      }
-      output.Ejecutivo = ejecutivoValue;
 
       BULK_TEXT_HEADERS.forEach(function (label) {
         const rawValue = normalizedValues[label];
@@ -3752,16 +3763,6 @@
         const tripInput = refs.editForm.querySelector('[name="trip"]');
         if (tripInput) {
           tripInput.focus();
-        }
-        return;
-      }
-      if (!ejecutivoValue) {
-        if (refs.editError) {
-          refs.editError.textContent = 'El campo Ejecutivo es obligatorio.';
-        }
-        const ejecutivoInput = refs.editForm.querySelector('[name="ejecutivo"]');
-        if (ejecutivoInput) {
-          ejecutivoInput.focus();
         }
         return;
       }

--- a/seguimiento_cargas_pwa/backend/Code.gs
+++ b/seguimiento_cargas_pwa/backend/Code.gs
@@ -148,7 +148,6 @@ function doPost(e) {
       var citaEntregaDate = parseDateSafe(p.citaEntrega, timeZone);
       var llegadaEntregaDate = parseDateSafe(p.llegadaEntrega, timeZone);
       var ejecutivo = (p.ejecutivo || p.Ejecutivo || '').trim();
-      if (!ejecutivo) throw new Error('Missing ejecutivo');
       var row = new Array(headers.length).fill('');
       var map = {
         'Ejecutivo': ejecutivo,
@@ -236,9 +235,6 @@ function doPost(e) {
         } else if (Number(tripKey) < 225000) {
           rowIssues.push('Trip menor a 225000');
         }
-        if (!ejecutivoKey) {
-          rowIssues.push('Ejecutivo vacío');
-        }
         if (rowIssues.length > 0) {
           invalidRows.push('Fila ' + (rowIndex + 2) + ': ' + rowIssues.join(', ') + '.');
           continue;
@@ -294,7 +290,6 @@ function doPost(e) {
       }
       // Parse dates using the sheet timezone to keep the submitted local time without adding offsets
       var ejecutivo = (p.ejecutivo || p.Ejecutivo || '').trim();
-      if (!ejecutivo) throw new Error('Missing ejecutivo');
       var citaCarga = parseDateSafe(p.citaCarga, timeZone);
       var llegadaCarga = parseDateSafe(p.llegadaCarga, timeZone);
       var citaEntrega = parseDateSafe(p.citaEntrega, timeZone);
@@ -331,7 +326,6 @@ function doPost(e) {
   } catch (err) {
     var status = (
       err.message === 'Trip not found' ||
-      err.message === 'Missing ejecutivo' ||
       err.message === 'Invalid trip' ||
       err.message === 'Trip must be >= 225000' ||
       err.message === 'Trip already exists'

--- a/seguimiento_cargas_pwa/bulkAddValidation.test.js
+++ b/seguimiento_cargas_pwa/bulkAddValidation.test.js
@@ -74,20 +74,22 @@ const result = callBulkAdd([
 ]);
 
 assert.strictEqual(result.success, true, 'bulkAdd should succeed even with invalid rows');
-assert.strictEqual(result.inserted, 1, 'Only one valid row should be inserted');
+assert.strictEqual(result.inserted, 2, 'Two valid rows should be inserted when only Trip is required');
 assert.deepStrictEqual(result.duplicates, [], 'No duplicates should be reported');
 assert.deepStrictEqual(
   result.invalidRows,
   [
     'Fila 2: Trip vacío.',
     'Fila 3: Trip inválido.',
-    'Fila 4: Trip menor a 225000.',
-    'Fila 5: Ejecutivo vacío.'
+    'Fila 4: Trip menor a 225000.'
   ],
   'Invalid rows should include detailed issues'
 );
-assert.strictEqual(appendedValues.length, 1, 'Only one row should be appended for valid data');
+assert.strictEqual(appendedValues.length, 2, 'Two rows should be appended for valid data');
 const tripIndex = headers.indexOf('Trip');
-assert.strictEqual(appendedValues[0][tripIndex], '225124', 'Trip should be trimmed and stored as string');
+const ejecutivoIndex = headers.indexOf('Ejecutivo');
+assert.strictEqual(appendedValues[0][tripIndex], '225123', 'Trip 225123 should be stored for rows with optional Ejecutivo');
+assert.strictEqual(appendedValues[0][ejecutivoIndex], '', 'Ejecutivo can remain blank in bulk uploads');
+assert.strictEqual(appendedValues[1][tripIndex], '225124', 'Trip should be trimmed and stored as string');
 
 console.log('Bulk add validation test passed.');

--- a/seguimiento_cargas_pwa/index.html
+++ b/seguimiento_cargas_pwa/index.html
@@ -174,7 +174,7 @@
         </div>
         <div class="form-field">
           <label for="editEjecutivo">Ejecutivo</label>
-          <input id="editEjecutivo" name="ejecutivo" type="text" required />
+          <input id="editEjecutivo" name="ejecutivo" type="text" />
         </div>
         <div class="form-field">
           <label for="editCaja">Caja</label>


### PR DESCRIPTION
## Summary
- require only the Trip column during bulk uploads while keeping the rest of the headers optional and ordered as in the template
- allow blank Ejecutivo values across the client and Apps Script backend when importing or editing records
- update the bulk upload validation test to cover inserts with optional Ejecutivo data

## Testing
- node bulkAddValidation.test.js
- node bulkAddDuplicates.test.js
- node bulkUploadPayload.test.js
- node fmtDate.test.js
- node formatHeaderLabel.test.js
- node backend.test.js
- node tripValidation.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e5d719bec8832b8052b13f089eaac3