### PR TITLE
Limit bulk upload to modern Excel formats

### DIFF
--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -1145,6 +1145,26 @@
   }
 
   const BULK_ALLOWED_EXTENSIONS = new Set(['xlsx', 'xlsm']);
+
+  function formatAllowedExtensionsMessage(allowedExtensions) {
+    const extensions = Array.from(allowedExtensions, (ext) => `.${ext}`);
+    if (extensions.length === 0) {
+      return '';
+    }
+    if (extensions.length === 1) {
+      return extensions[0];
+    }
+    if (extensions.length === 2) {
+      return `${extensions[0]} o ${extensions[1]}`;
+    }
+    const head = extensions.slice(0, -1).join(', ');
+    const tail = extensions.at(-1);
+    return `${head} o ${tail}`;
+  }
+
+  const BULK_ALLOWED_EXTENSIONS_MESSAGE = formatAllowedExtensionsMessage(
+    BULK_ALLOWED_EXTENSIONS,
+  );
   const BULK_REQUIRED_HEADERS = ['Trip'];
   const BULK_TEXT_HEADERS = [
     'Ejecutivo',
@@ -2315,7 +2335,10 @@
       }
       const extension = getFileExtension(file.name);
       if (!BULK_ALLOWED_EXTENSIONS.has(extension)) {
-        setStatus('El archivo debe estar en formato .xlsx o .xlsm.', 'error');
+        setStatus(
+          `El archivo debe estar en formato ${BULK_ALLOWED_EXTENSIONS_MESSAGE}.`,
+          'error',
+        );
         return;
       }
       if (!state.currentUser) {

--- a/seguimiento_cargas_pwa/bulkAllowedExtensionsSync.test.js
+++ b/seguimiento_cargas_pwa/bulkAllowedExtensionsSync.test.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const htmlPath = path.join(__dirname, 'index.html');
+const appScriptPath = path.join(__dirname, 'app.js');
+
+const htmlContent = fs.readFileSync(htmlPath, 'utf8');
+const inputMatch = htmlContent.match(/<input[\s\S]*?data-bulk-upload-input[\s\S]*?>/);
+
+assert.ok(inputMatch, 'No se encontró el input de carga masiva.');
+
+const acceptMatch = inputMatch[0].match(/accept="([^"]+)"/);
+
+assert.ok(acceptMatch, 'No se encontró el atributo accept del input de carga masiva.');
+
+const acceptedExtensionsFromHtml = acceptMatch[1]
+  .split(',')
+  .map((ext) => ext.trim().replace(/^[.]/, ''))
+  .filter(Boolean)
+  .sort();
+
+const appScriptContent = fs.readFileSync(appScriptPath, 'utf8');
+const bulkExtensionsMatch = appScriptContent.match(
+  /const BULK_ALLOWED_EXTENSIONS = new Set\((\[[^\]]*\])\)/,
+);
+
+assert.ok(
+  bulkExtensionsMatch,
+  'No se encontró la constante BULK_ALLOWED_EXTENSIONS en app.js.',
+);
+
+const extensionsArrayLiteral = bulkExtensionsMatch[1];
+const allowedExtensionsFromScript = Array.from(
+  vm.runInNewContext(extensionsArrayLiteral),
+  (ext) => String(ext).trim(),
+)
+  .filter(Boolean)
+  .sort();
+
+assert.deepStrictEqual(
+  acceptedExtensionsFromHtml,
+  allowedExtensionsFromScript,
+  'Las extensiones permitidas del input y de la validación no coinciden.',
+);
+
+console.log('Las extensiones permitidas están sincronizadas entre la interfaz y la lógica.');

--- a/seguimiento_cargas_pwa/index.html
+++ b/seguimiento_cargas_pwa/index.html
@@ -38,7 +38,7 @@
         <button type="button" class="button button--secondary" data-action="bulk-upload">Carga masiva</button>
         <input
           type="file"
-          accept=".xlsx,.xls,.csv"
+          accept=".xlsx,.xlsm"
           data-bulk-upload-input
           class="is-hidden"
           tabindex="-1"


### PR DESCRIPTION
## Summary
- restrict the bulk upload file picker to .xlsx and .xlsm extensions
- centralize the bulk upload validation message so it reflects the allowed extensions set
- add a regression test that ensures the UI accept filter and validation list stay in sync

## Testing
- node seguimiento_cargas_pwa/bulkAllowedExtensionsSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5eb80b11c832b88271a1119f676b1