### PR TITLE
Rechaza ZIP en carga masiva y documenta uso de XLSX

### DIFF
--- a/seguimiento_cargas_pwa/README.md
+++ b/seguimiento_cargas_pwa/README.md
@@ -17,6 +17,7 @@ Aplicación PWA para seguimiento de cargas en tiempo real, conectada a Google Sh
 - Columnas esperadas:
   - Trip, Caja, Referencia, Cliente, Destino, Estatus, Segmento, TR-MX, TR-USA, Cita carga, Llegada carga, Cita entrega, Llegada entrega, Comentarios, Docs, Tracking
 - Las fechas deben enviarse en formato `DD/MM/YYYY HH:mm:ss` (ejemplo: `26/08/2025 22:00:00`).
+- La carga masiva ahora acepta únicamente archivos de Excel con extensión `.xlsx` (o `.xlsm`). Los archivos `.zip` dejaron de ser compatibles.
 
 ## Inicio de sesión y control de acceso
 

--- a/seguimiento_cargas_pwa/app.js
+++ b/seguimiento_cargas_pwa/app.js
@@ -1146,6 +1146,13 @@
 
   const BULK_ALLOWED_EXTENSIONS = new Set(['xlsx', 'xlsm']);
 
+  const BULK_REJECTED_EXTENSIONS = new Map([
+    [
+      'zip',
+      'Los archivos ZIP ya no son compatibles con la carga masiva. Utiliza un archivo .xlsx.'
+    ]
+  ]);
+
   function formatAllowedExtensionsMessage(allowedExtensions) {
     const extensions = Array.from(allowedExtensions, (ext) => `.${ext}`);
     if (extensions.length === 0) {
@@ -2630,6 +2637,16 @@
       }
 
       const extension = getFileExtension(file.name);
+      if (BULK_REJECTED_EXTENSIONS.has(extension)) {
+        const message = BULK_REJECTED_EXTENSIONS.get(extension);
+        const error = new Error(message);
+        setStatus(message, 'error');
+        emitLog(message, 'error');
+        emitError(error);
+        finish({ success: false, error: error });
+        return { success: false, error: error };
+      }
+
       if (!BULK_ALLOWED_EXTENSIONS.has(extension)) {
         const message = `El archivo debe estar en formato ${BULK_ALLOWED_EXTENSIONS_MESSAGE}.`;
         const error = new Error(message);

--- a/seguimiento_cargas_pwa/bulkRejectZip.test.js
+++ b/seguimiento_cargas_pwa/bulkRejectZip.test.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const appScriptPath = path.join(__dirname, 'app.js');
+const appScriptContent = fs.readFileSync(appScriptPath, 'utf8');
+
+const allowedMatch = appScriptContent.match(
+  /const BULK_ALLOWED_EXTENSIONS = new Set\((\[[^\]]*\])\)/
+);
+
+assert.ok(
+  allowedMatch,
+  'No se encontró la constante BULK_ALLOWED_EXTENSIONS en app.js.',
+);
+
+const allowedExtensions = Array.from(
+  vm.runInNewContext(allowedMatch[1]),
+  (ext) => String(ext).trim(),
+).filter(Boolean);
+
+assert.ok(
+  !allowedExtensions.includes('zip'),
+  'La carga masiva no debe aceptar archivos .zip.',
+);
+
+const rejectedMatch = appScriptContent.match(
+  /const BULK_REJECTED_EXTENSIONS = new Map\((\[[\s\S]*?\])\)/
+);
+
+assert.ok(
+  rejectedMatch,
+  'No se encontró la constante BULK_REJECTED_EXTENSIONS en app.js.',
+);
+
+const rejectedPairs = vm.runInNewContext(rejectedMatch[1]);
+const rejectedMap = new Map(
+  rejectedPairs.map((pair) => [String(pair[0]), String(pair[1])]),
+);
+
+assert.ok(
+  rejectedMap.has('zip'),
+  'El archivo .zip debe rechazarse explícitamente en la carga masiva.',
+);
+
+assert.ok(
+  /\.xlsx/.test(rejectedMap.get('zip')),
+  'El mensaje de rechazo para .zip debe indicar el uso de un archivo .xlsx.',
+);
+
+console.log('La validación de extensiones para carga masiva es correcta.');


### PR DESCRIPTION
## Summary
- añade una lista explícita de extensiones rechazadas para impedir cargas masivas con archivos ZIP
- muestra un mensaje claro al usuario cuando intenta subir un ZIP e indica utilizar un XLSX
- documenta la nueva restricción y agrega una prueba que asegura la configuración de extensiones permitidas y rechazadas

## Testing
- node seguimiento_cargas_pwa/bulkRejectZip.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e5fc2a93b8832b9730eabeb6211e17